### PR TITLE
Update main branch 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:3.14-alpine
 
+RUN apk upgrade --no-cache
 RUN apk add --no-cache build-base musl-dev gcc linux-headers libffi-dev openssl-dev
 
 RUN mkdir -p /perun/upload

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-alpine
+FROM python:3.14-alpine
 
 RUN apk add --no-cache build-base musl-dev gcc linux-headers libffi-dev openssl-dev
 


### PR DESCRIPTION
-> bump base image used in Dockerfile to python3.14-alpine, because  python3.10-alpine  no longer receives updates, or only very irregular ones.